### PR TITLE
fix rentcap out of bounds

### DIFF
--- a/components/rentalert.tsx
+++ b/components/rentalert.tsx
@@ -18,14 +18,19 @@ const RentAlert: NextPage<Props> = function RentAlert(props) {
   const previousRent = getPreviousRent(props.rentHistory).rent;
   const currentRentStartDate = getCurrentRent(props.rentHistory).startDate;
 
+  let statewideMaxRent = 0;
+  let statewideMaxRentDisplay = null;
   const statewideRentCap = lookupRentCap(
     props.location.statewideRentCap,
     new Date(currentRentStartDate),
   );
-  const statewideMaxRent = (1 + statewideRentCap) * previousRent;
-  const statewideMaxRentDisplay = statewideMaxRent.toFixed(2);
 
-  let localRentCap = null;
+  if (statewideRentCap) {
+    statewideMaxRent = (1 + statewideRentCap) * previousRent;
+    statewideMaxRentDisplay = statewideMaxRent.toFixed(2);
+  }
+
+  let localRentCap = undefined;
   let localMaxRent = 0;
   let localMaxRentDisplay = null;
   if (props.location.localRentCap) {
@@ -33,8 +38,10 @@ const RentAlert: NextPage<Props> = function RentAlert(props) {
       props.location.localRentCap,
       currentRentStartDate,
     );
-    localMaxRent = (1 + localRentCap) * previousRent;
-    localMaxRentDisplay = localMaxRent.toFixed(2);
+    if (localRentCap) {
+      localMaxRent = (1 + localRentCap) * previousRent;
+      localMaxRentDisplay = localMaxRent.toFixed(2);
+    }
   }
 
   return (
@@ -47,7 +54,8 @@ const RentAlert: NextPage<Props> = function RentAlert(props) {
         })}
         <p className="font-bold pr-4">${currentRent}</p>
       </div>
-      {currentRent > statewideMaxRent || currentRent > localMaxRent ? (
+      {(statewideMaxRent && currentRent > statewideMaxRent) ||
+      (localMaxRent && currentRent > localMaxRent) ? (
         <p className="text-blue font-medium py-2 text-lg">
           {t('calculator.alert.illegal')}
         </p>
@@ -56,7 +64,7 @@ const RentAlert: NextPage<Props> = function RentAlert(props) {
           {t('calculator.alert.legal')}
         </p>
       )}
-      {localRentCap != null && (
+      {localRentCap != undefined && (
         <div className="mb-4">
           <div className="flex flex-row text-blue text-lg font-bold">
             <img
@@ -88,31 +96,33 @@ const RentAlert: NextPage<Props> = function RentAlert(props) {
           </div>
         </div>
       )}
-      <div className="mb-4">
-        <div className="flex flex-row text-blue text-lg font-bold">
-          <img
-            src={
-              currentRent > statewideMaxRent
-                ? '/img/warning-icon.svg'
-                : '/img/check-icon.svg'
-            }
-            alt="warning icon"
-            className="pt-1 pr-2 absolute"
-          />
-          <div className="flex flex-col pl-8 pr-24">
-            <p>{t('calculator.alert.statewide-max-rent')}</p>
-            <p className="text-gray font-light text-sm italic">
-              {t('calculator.alert.max-increase', {
-                cap: (statewideRentCap * 100).toFixed(2),
-                rent: previousRent,
-              })}
+      {statewideRentCap != undefined && (
+        <div className="mb-4">
+          <div className="flex flex-row text-blue text-lg font-bold">
+            <img
+              src={
+                currentRent > statewideMaxRent
+                  ? '/img/warning-icon.svg'
+                  : '/img/check-icon.svg'
+              }
+              alt="warning icon"
+              className="pt-1 pr-2 absolute"
+            />
+            <div className="flex flex-col pl-8 pr-24">
+              <p>{t('calculator.alert.statewide-max-rent')}</p>
+              <p className="text-gray font-light text-sm italic">
+                {t('calculator.alert.max-increase', {
+                  cap: (statewideRentCap * 100).toFixed(2),
+                  rent: previousRent,
+                })}
+              </p>
+            </div>
+            <p className="border border-blue absolute  rounded text-blue text-lg font-medium py-2 my-1 px-2 right-[3em] md:right-[5em] lg:px-10 lg:right-[8em]">
+              ${statewideMaxRentDisplay}
             </p>
           </div>
-          <p className="border border-blue absolute  rounded text-blue text-lg font-medium py-2 my-1 px-2 right-[3em] md:right-[5em] lg:px-10 lg:right-[8em]">
-            ${statewideMaxRentDisplay}
-          </p>
         </div>
-      </div>
+      )}
       <div>
         <p className="text-blue font-medium py-2 text-md">
           {t('calculator.alert.rate-explanation')}

--- a/pages/calculator/index.tsx
+++ b/pages/calculator/index.tsx
@@ -105,7 +105,7 @@ const Calculator: NextPage<Props> = function Calculator({ location }) {
           {t('submit')}
         </button>
         {location?.type === 'unknown' &&
-          `Could not find ZIP Code ${location.zip}`}
+          `Could not find California ZIP Code ${location.zip}`}
       </form>
     </Layout>
   );

--- a/pages/calculator/zip/[zip]/index.tsx
+++ b/pages/calculator/zip/[zip]/index.tsx
@@ -3,11 +3,11 @@ import { GetServerSideProps, NextPage } from 'next';
 import Link from 'next/link';
 import { useTranslation } from 'next-i18next';
 import { serverSideTranslations } from 'next-i18next/serverSideTranslations';
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 
 import { FullLocation } from '@/types/location';
 import { RentEntry, RentHistory } from '@/types/calculator';
-import { locationFromZip, lookupRentCap } from '@/utils/location';
+import { locationFromZip } from '@/utils/location';
 import Layout from '@/components/layout';
 import RentRow from '@/components/rentrow';
 import RentAlert from '@/components/rentalert';

--- a/pages/eligibility/index.tsx
+++ b/pages/eligibility/index.tsx
@@ -97,7 +97,7 @@ const Eligibility: NextPage<Props> = function Eligibility({ location }) {
           {t('submit')}
         </button>
         {location?.type === 'unknown' &&
-          `Could not find ZIP Code ${location.zip}`}
+          `Could not find California ZIP Code ${location.zip}`}
       </form>
       <Accordion
         title={t('eligibility-more.title')}

--- a/utils/location.ts
+++ b/utils/location.ts
@@ -49,8 +49,8 @@ export function locationFromZip(zip: string): Location {
 export function lookupRentCap(
   rentCapHistory: RentCapHistory,
   date: Date,
-): number {
-  let rate = 0;
+): number | undefined {
+  let rate = undefined;
 
   rentCapHistory.map((x, i) => {
     const start = new Date(x.start);


### PR DESCRIPTION
Return `undefined` from `lookupRentCap` if no rate found and in React only show Local Max Rent data if one was found in the given time range. Since this is only for California residents, there should always be a State Max Rent I believe. Also small fix to print `Could not find **California** zip code` since putting in non California zip codes doesn't work.

Screenshot from before/after fix:

<img width="770" alt="Screen Shot 2022-11-26 at 8 29 00 PM" src="https://user-images.githubusercontent.com/9343424/204119246-bf053617-7877-411f-88c5-bc024d26d228.png">


<img width="758" alt="Screen Shot 2022-11-26 at 8 25 10 PM" src="https://user-images.githubusercontent.com/9343424/204119157-df7f58d5-2809-4d15-be05-352f2bfe0a45.png">
