### PR TITLE
zip: regex for 5 number zip code

### DIFF
--- a/pages/calculator/index.tsx
+++ b/pages/calculator/index.tsx
@@ -84,7 +84,7 @@ const Calculator: NextPage<Props> = function Calculator({ location }) {
           name="zip"
           type="text"
           inputMode="numeric"
-          pattern="^(?(^00000(|-0000))|(\d{5}(|-\d{4})))$"
+          pattern="^\d{5}?$"
           placeholder="90001"
           className="border-2 text-lg rounded border-gray outline-none p-3 my-3"
           required

--- a/pages/eligibility/index.tsx
+++ b/pages/eligibility/index.tsx
@@ -77,7 +77,7 @@ const Eligibility: NextPage<Props> = function Eligibility({ location }) {
           name="zip"
           type="text"
           inputMode="numeric"
-          pattern="^(?(^00000(|-0000))|(\d{5}(|-\d{4})))$"
+          pattern="^\d{5}?$"
           placeholder="90001"
           className="border-2 text-lg rounded border-gray outline-none p-3 my-3"
           required


### PR DESCRIPTION
We only support 5 digit zipcode anyway (don't support like 90001-1234), so just simplify the regex